### PR TITLE
Fix incorrect `this` binding for Map methods in store module

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -42,10 +42,10 @@ export const saveEmail = (email: Email) => {
   sendEmailToSmtp(email);
 };
 
-export const hasTemplate = store.templates.has;
-export const getTemplate = store.templates.get;
-export const setTemplate = store.templates.set;
-export const deleteTemplate = store.templates.delete;
+export const hasTemplate = (key: string) => store.templates.has(key);
+export const getTemplate = (key: string) => store.templates.get(key);
+export const setTemplate = (key: string, value: Template) => store.templates.set(key, value);
+export const deleteTemplate = (key: string) => store.templates.delete(key);
 
 export const clearStore = () => {
   store.emails = [];


### PR DESCRIPTION
Thank you for creating this fantastic library.🎉

This pull request resolves a issue encountered when using the SES V2 createEmailTemplate endpoint, where a `TypeError: Method Map.prototype.has called on incompatible receiver undefined was thrown`. 

This error stemmed from an incorrect this context for Map prototype methods (has, get, set, delete) when called directly as properties of the store object. Consequently, these methods were invoked on an incompatible receiver (undefined), leading to runtime exceptions.

The core of the issue was the loss of the this context for Map methods, which are not bound to the store.templates Map instance as expected in JavaScript's execution model. To address this, we've introduced wrapper functions (hasTemplate, getTemplate, setTemplate, deleteTemplate) that correctly bind the this context to store.templates. These wrappers ensure that the Map methods are invoked on the correct receiver, thereby maintaining the integrity of the this context.

Changes Made:

* Modified the implementation to include wrapper functions for Map methods, ensuring the correct this context when performing operations on the store.templates Map.

Error:
```
TypeError: Method Map.prototype.has called on incompatible receiver undefined
    at has (<anonymous>)
    at handler (/usr/local/lib/node_modules/aws-ses-v2-local/dist/v2/createEmailTemplate.js:16:33)
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/route.js:144:13)
    at Route.dispatch (/usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/route.js:114:3)
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/layer.js:95:5)
    at /usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/index.js:346:12)
    at next (/usr/local/lib/node_modules/aws-ses-v2-local/node_modules/express/lib/router/index.js:280:10)
    at /usr/local/lib/node_modules/aws-ses-v2-local/dist/index.js:64:9
```