### PR TITLE
fix: path to build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,9 +3,11 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": true,
+    "rootDir": "src",
   },
   "exclude": [
     "test/**/*",
     "**/*.test.ts",
-  ],
+    "vitest.config.mts"
+  ]
 }


### PR DESCRIPTION
resolve https://github.com/domdomegg/aws-ses-v2-local/issues/36

fix a path to build so that `build` directory contains `v1` and `v2` directory directly instead of covered by `src` directory