### PR TITLE
Add GetEmailTemplate support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:binary_exists": "npm run prepublishOnly && node -e \"require('fs').access(require('./package.json').bin['aws-ses-v2-local'], (err) => process.exit(err ? 1 : 0))\"",
     "test:watch": "vitest",
     "lint": "eslint",
+    "format": "eslint --fix",
     "clean": "rm -rf dist",
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import v1SendRawEmail from './v1/sendRawEmail';
 import v1SendEmail from './v1/sendEmail';
 import v2CreateEmailTemplate from './v2/createEmailTemplate';
+import v2GetEmailTemplate from './v2/getEmailTemplate';
 import v2DeleteEmailTemplate from './v2/deleteEmailTemplate';
 import v2GetAccount from './v2/getAccount';
 import v2SendEmail from './v2/sendEmail';
@@ -112,6 +113,7 @@ const server = async (partialConfig: Partial<Config> = {}): Promise<Server> => {
 
 	// SES V2 - template handling.
 	app.post('/v2/email/templates', v2CreateEmailTemplate);
+	app.get('/v2/email/templates/:TemplateName', v2GetEmailTemplate);
 	app.delete('/v2/email/templates/:TemplateName', v2DeleteEmailTemplate);
 
 	// SES V2 - account handling.

--- a/src/v2/getEmailTemplate.ts
+++ b/src/v2/getEmailTemplate.ts
@@ -1,0 +1,21 @@
+import type {RequestHandler} from 'express';
+import {hasTemplate, getTemplate} from '../store';
+
+const handler: RequestHandler = (req, res) => {
+	const templateName = req.params.TemplateName;
+
+	if (!templateName) {
+		res.status(400).send({type: 'BadRequestException', message: 'Bad Request Exception', detail: 'aws-ses-v2-local: Must provide a template name.'});
+		return;
+	}
+
+	const template = getTemplate(templateName);
+	if (!hasTemplate(templateName) || !template?.TemplateName || !template?.TemplateContent) {
+		res.status(404).send({type: 'NotFoundException', message: 'The resource you attempted to access doesn\'t exist.'});
+		return;
+	}
+
+	res.status(200).send(template);
+};
+
+export default handler;


### PR DESCRIPTION
Fix: #46 

---

```shellsession
$ git diff docker-compose.example.yaml
diff --git a/docker-compose.example.yaml b/docker-compose.example.yaml
index 6513a8d..650a276 100644
--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,6 +1,6 @@
 services:
   aws-ses:
-    image: ghcr.io/domdomegg/aws-ses-v2-local
+    # image: ghcr.io/domdomegg/aws-ses-v2-local
     build:
       context: .
     container_name: aws-ses-v2-local

$ docker compose -f docker-compose.example.yaml up -d
...
```

```shellsession
$ AWS_ACCESS_KEY_ID="a" AWS_SECRET_ACCESS_KEY="a" aws sesv2 create-email-template \
  --template-name 'foo'
  --template-content '{"Subject":"test","Text":"hoge"}'
  --endpoint-url http://localhost:8005
  --region aws-ses-v2-local 

$ AWS_ACCESS_KEY_ID="a" AWS_SECRET_ACCESS_KEY="a" aws sesv2 get-email-template \
  --template-name 'foo' \
  --endpoint-url http://localhost:8005 \
  --region aws-ses-v2-local
{
    "TemplateName": "foo",
    "TemplateContent": {
        "Subject": "test",
        "Text": "hoge"
    }
}
```