### PR TITLE
test: add tests for mocked SES v2 APIs

### DIFF
--- a/test/globals.ts
+++ b/test/globals.ts
@@ -1,6 +1,4 @@
 
-/* eslint-disable no-var */
-
 import type {Server} from 'http';
 
 declare global {

--- a/test/v2/createEmailTemplate.test.ts
+++ b/test/v2/createEmailTemplate.test.ts
@@ -1,0 +1,178 @@
+import {test, expect} from 'vitest';
+import {SESv2Client, CreateEmailTemplateCommand, GetEmailTemplateCommand} from '@aws-sdk/client-sesv2';
+import axios from 'axios';
+import {baseURL} from '../globals';
+
+test('can create email template with all fields', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'create-template-test-all-fields';
+	const templateContent = {
+		Subject: 'Test Subject {{name}}',
+		Html: '<h1>Hello {{name}}</h1><p>This is a test email.</p>',
+		Text: 'Hello {{name}}\n\nThis is a test email.',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	const response = await ses.send(new GetEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	expect(response.TemplateName).toBe(templateName);
+	expect(response.TemplateContent).toMatchObject(templateContent);
+});
+
+test('can create email template with only subject', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'create-template-test-subject-only';
+	const templateContent = {
+		Subject: 'Test Subject Only',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	const response = await ses.send(new GetEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	expect(response.TemplateName).toBe(templateName);
+	expect(response.TemplateContent?.Subject).toBe(templateContent.Subject);
+});
+
+test('can create email template with only HTML', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'create-template-test-html-only';
+	const templateContent = {
+		Html: '<h1>HTML Only Template</h1>',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	const response = await ses.send(new GetEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	expect(response.TemplateName).toBe(templateName);
+	expect(response.TemplateContent?.Html).toBe(templateContent.Html);
+});
+
+test('can create email template with only text', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'create-template-test-text-only';
+	const templateContent = {
+		Text: 'Text only template content',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	const response = await ses.send(new GetEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	expect(response.TemplateName).toBe(templateName);
+	expect(response.TemplateContent?.Text).toBe(templateContent.Text);
+});
+
+test('returns error when creating template that already exists', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'duplicate-template-test';
+	const templateContent = {
+		Subject: 'Duplicate Test Subject',
+		Html: '<h1>Duplicate Test</h1>',
+		Text: 'Duplicate Test',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	await expect(ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}))).rejects.toThrow();
+});
+
+test('returns error when template name is missing', async () => {
+	await expect(axios({
+		method: 'post',
+		baseURL,
+		url: '/v2/email/templates',
+		data: {
+			TemplateContent: {
+				Subject: 'Test Subject',
+			},
+		},
+	})).rejects.toThrow();
+});
+
+test('returns error when template content is missing', async () => {
+	await expect(axios({
+		method: 'post',
+		baseURL,
+		url: '/v2/email/templates',
+		data: {
+			TemplateName: 'test-template-no-content',
+		},
+	})).rejects.toThrow();
+});
+
+test('returns error when request body is invalid', async () => {
+	await expect(axios({
+		method: 'post',
+		baseURL,
+		url: '/v2/email/templates',
+		data: {
+			InvalidField: 'invalid-value',
+		},
+	})).rejects.toThrow();
+});
+
+test('returns error when template content is empty object', async () => {
+	await expect(axios({
+		method: 'post',
+		baseURL,
+		url: '/v2/email/templates',
+		data: {
+			TemplateName: 'empty-content-template',
+			TemplateContent: {},
+		},
+	})).rejects.toThrow();
+});

--- a/test/v2/deleteEmailTemplate.test.ts
+++ b/test/v2/deleteEmailTemplate.test.ts
@@ -1,0 +1,57 @@
+import {test, expect} from 'vitest';
+import {SESv2Client, DeleteEmailTemplateCommand, CreateEmailTemplateCommand} from '@aws-sdk/client-sesv2';
+import axios from 'axios';
+import {baseURL} from '../globals';
+
+test('can delete existing email template', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'template-to-delete';
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: {
+			Subject: 'Test Subject',
+			Html: '<h1>Hello</h1>',
+			Text: 'Hello',
+		},
+	}));
+
+	await ses.send(new DeleteEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	await expect(axios({
+		method: 'get',
+		baseURL,
+		url: `/v2/email/templates/${templateName}`,
+	})).rejects.toThrow();
+});
+
+test('returns error when deleting non-existent template', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new DeleteEmailTemplateCommand({
+		TemplateName: 'non-existent-template',
+	}))).rejects.toThrow();
+});
+
+test('returns error when template name is missing', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new DeleteEmailTemplateCommand({
+		TemplateName: '',
+	}))).rejects.toThrow();
+});

--- a/test/v2/getAccount.test.ts
+++ b/test/v2/getAccount.test.ts
@@ -1,3 +1,4 @@
+import type {Server} from 'http';
 import {
 	test, expect, vi, afterEach,
 } from 'vitest';
@@ -6,13 +7,13 @@ import axios from 'axios';
 import server from '../../src';
 import {getAddress} from '../../src/address';
 
-let testServer: any;
+let testServer: Server | null = null;
 let testBaseURL: string;
 
 afterEach(async () => {
 	if (testServer) {
 		await new Promise<void>((resolve, reject) => {
-			testServer.close((err: Error) => {
+			testServer!.close((err) => {
 				if (err) {
 					reject(err);
 				} else {

--- a/test/v2/getAccount.test.ts
+++ b/test/v2/getAccount.test.ts
@@ -1,0 +1,272 @@
+import {
+	test, expect, vi, afterEach,
+} from 'vitest';
+import {SESv2Client, GetAccountCommand} from '@aws-sdk/client-sesv2';
+import axios from 'axios';
+import server from '../../src';
+import {getAddress} from '../../src/address';
+
+let testServer: any;
+let testBaseURL: string;
+
+afterEach(async () => {
+	if (testServer) {
+		await new Promise<void>((resolve, reject) => {
+			testServer.close((err: Error) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+		testServer = null;
+	}
+});
+
+async function startTestServer() {
+	testServer = await server({port: 0, host: '127.0.0.1'});
+	testBaseURL = getAddress(testServer);
+	return testBaseURL;
+}
+
+test('can get account information when AWS_SES_ACCOUNT is set', async () => {
+	const mockAccount = {
+		DedicatedIpAutoWarmupEnabled: true,
+		Details: {
+			AdditionalContactEmailAddresses: ['contact@example.com'],
+			ContactLanguage: 'EN',
+			MailType: 'MARKETING',
+			ReviewDetails: {
+				CaseId: 'case-123',
+				Status: 'GRANTED',
+			},
+			UseCaseDescription: 'Marketing emails for our company',
+			WebsiteURL: 'https://example.com',
+		},
+		EnforcementStatus: 'HEALTHY',
+		ProductionAccessEnabled: true,
+		SendingEnabled: true,
+		SendQuota: {
+			Max24HourSend: 1000,
+			MaxSendRate: 10,
+			SentLast24Hours: 50,
+		},
+		SuppressionAttributes: {
+			SuppressedReasons: ['BOUNCE', 'COMPLAINT'],
+		},
+	};
+
+	vi.stubEnv('AWS_SES_ACCOUNT', JSON.stringify(mockAccount));
+
+	const baseURL = await startTestServer();
+
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const response = await ses.send(new GetAccountCommand({}));
+
+	expect(response).toMatchObject(mockAccount);
+});
+
+test('can get account information with minimal valid data', async () => {
+	const mockAccount = {
+		DedicatedIpAutoWarmupEnabled: false,
+		Details: {
+			AdditionalContactEmailAddresses: [],
+			ContactLanguage: 'EN',
+			MailType: 'TRANSACTIONAL',
+			ReviewDetails: {
+				CaseId: '',
+				Status: 'PENDING',
+			},
+			UseCaseDescription: 'Transactional emails',
+			WebsiteURL: '',
+		},
+		EnforcementStatus: 'UNDER_REVIEW',
+		ProductionAccessEnabled: false,
+		SendingEnabled: false,
+		SendQuota: {
+			Max24HourSend: 0,
+			MaxSendRate: 0,
+			SentLast24Hours: 0,
+		},
+		SuppressionAttributes: {
+			SuppressedReasons: [],
+		},
+	};
+
+	vi.stubEnv('AWS_SES_ACCOUNT', JSON.stringify(mockAccount));
+
+	const baseURL = await startTestServer();
+
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const response = await ses.send(new GetAccountCommand({}));
+
+	expect(response).toMatchObject(mockAccount);
+});
+
+test('returns error when AWS_SES_ACCOUNT is not set', async () => {
+	vi.stubEnv('AWS_SES_ACCOUNT', undefined);
+
+	const baseURL = await startTestServer();
+
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new GetAccountCommand({}))).rejects.toThrow();
+});
+
+test('returns error when AWS_SES_ACCOUNT contains invalid JSON', async () => {
+	vi.stubEnv('AWS_SES_ACCOUNT', 'invalid-json');
+
+	const baseURL = await startTestServer();
+
+	await expect(axios({
+		method: 'get',
+		baseURL,
+		url: '/v2/account',
+	})).rejects.toThrow();
+});
+
+test('returns error when AWS_SES_ACCOUNT has invalid schema - missing required fields', async () => {
+	const invalidAccount = {
+		DedicatedIpAutoWarmupEnabled: true,
+	};
+
+	vi.stubEnv('AWS_SES_ACCOUNT', JSON.stringify(invalidAccount));
+
+	const baseURL = await startTestServer();
+
+	await expect(axios({
+		method: 'get',
+		baseURL,
+		url: '/v2/account',
+	})).rejects.toThrow();
+});
+
+test('returns error when AWS_SES_ACCOUNT has invalid schema - wrong data types', async () => {
+	const invalidAccount = {
+		DedicatedIpAutoWarmupEnabled: 'not-a-boolean',
+		Details: {
+			AdditionalContactEmailAddresses: 'not-an-array',
+			ContactLanguage: 123,
+			MailType: 'MARKETING',
+			ReviewDetails: {
+				CaseId: 'case-123',
+				Status: 'GRANTED',
+			},
+			UseCaseDescription: 'Test description',
+			WebsiteURL: 'https://example.com',
+		},
+		EnforcementStatus: 'HEALTHY',
+		ProductionAccessEnabled: true,
+		SendingEnabled: true,
+		SendQuota: {
+			Max24HourSend: 'not-a-number',
+			MaxSendRate: 10,
+			SentLast24Hours: 50,
+		},
+		SuppressionAttributes: {
+			SuppressedReasons: ['BOUNCE', 'COMPLAINT'],
+		},
+	};
+
+	vi.stubEnv('AWS_SES_ACCOUNT', JSON.stringify(invalidAccount));
+
+	const baseURL = await startTestServer();
+
+	await expect(axios({
+		method: 'get',
+		baseURL,
+		url: '/v2/account',
+	})).rejects.toThrow();
+});
+
+test('returns error when AWS_SES_ACCOUNT has invalid nested object structure', async () => {
+	const invalidAccount = {
+		DedicatedIpAutoWarmupEnabled: true,
+		Details: {
+			AdditionalContactEmailAddresses: ['contact@example.com'],
+			ContactLanguage: 'EN',
+			MailType: 'MARKETING',
+			ReviewDetails: 'not-an-object',
+			UseCaseDescription: 'Test description',
+			WebsiteURL: 'https://example.com',
+		},
+		EnforcementStatus: 'HEALTHY',
+		ProductionAccessEnabled: true,
+		SendingEnabled: true,
+		SendQuota: {
+			Max24HourSend: 1000,
+			MaxSendRate: 10,
+			SentLast24Hours: 50,
+		},
+		SuppressionAttributes: {
+			SuppressedReasons: ['BOUNCE', 'COMPLAINT'],
+		},
+	};
+
+	vi.stubEnv('AWS_SES_ACCOUNT', JSON.stringify(invalidAccount));
+
+	const baseURL = await startTestServer();
+
+	await expect(axios({
+		method: 'get',
+		baseURL,
+		url: '/v2/account',
+	})).rejects.toThrow();
+});
+
+test('can handle account with empty string values', async () => {
+	const mockAccount = {
+		DedicatedIpAutoWarmupEnabled: false,
+		Details: {
+			AdditionalContactEmailAddresses: [],
+			ContactLanguage: '',
+			MailType: '',
+			ReviewDetails: {
+				CaseId: '',
+				Status: '',
+			},
+			UseCaseDescription: '',
+			WebsiteURL: '',
+		},
+		EnforcementStatus: '',
+		ProductionAccessEnabled: false,
+		SendingEnabled: false,
+		SendQuota: {
+			Max24HourSend: 0,
+			MaxSendRate: 0,
+			SentLast24Hours: 0,
+		},
+		SuppressionAttributes: {
+			SuppressedReasons: [],
+		},
+	};
+
+	vi.stubEnv('AWS_SES_ACCOUNT', JSON.stringify(mockAccount));
+
+	const baseURL = await startTestServer();
+
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const response = await ses.send(new GetAccountCommand({}));
+
+	expect(response).toMatchObject(mockAccount);
+});

--- a/test/v2/getEmailTemplate.test.ts
+++ b/test/v2/getEmailTemplate.test.ts
@@ -1,0 +1,79 @@
+import {test, expect} from 'vitest';
+import {SESv2Client, GetEmailTemplateCommand, CreateEmailTemplateCommand} from '@aws-sdk/client-sesv2';
+import {baseURL} from '../globals';
+
+test('can get existing email template', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'get-template-test';
+	const templateContent = {
+		Subject: 'Test Subject {{name}}',
+		Html: '<h1>Hello {{name}}</h1>',
+		Text: 'Hello {{name}}',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	const response = await ses.send(new GetEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	expect(response.TemplateName).toBe(templateName);
+	expect(response.TemplateContent).toMatchObject(templateContent);
+});
+
+test('returns error when getting non-existent template', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new GetEmailTemplateCommand({
+		TemplateName: 'non-existent-template',
+	}))).rejects.toThrow();
+});
+
+test('returns error when template name is missing', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new GetEmailTemplateCommand({
+		TemplateName: '',
+	}))).rejects.toThrow();
+});
+
+test('can get template with only required fields', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'minimal-template';
+	const templateContent = {
+		Subject: 'Minimal Subject',
+	};
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: templateContent,
+	}));
+
+	const response = await ses.send(new GetEmailTemplateCommand({
+		TemplateName: templateName,
+	}));
+
+	expect(response.TemplateName).toBe(templateName);
+	expect(response.TemplateContent?.Subject).toBe(templateContent.Subject);
+});

--- a/test/v2/sendBulkEmail.test.ts
+++ b/test/v2/sendBulkEmail.test.ts
@@ -1,0 +1,307 @@
+import {test, expect} from 'vitest';
+import {SESv2Client, SendBulkEmailCommand, CreateEmailTemplateCommand} from '@aws-sdk/client-sesv2';
+import axios from 'axios';
+import {type Store} from '../../src/store';
+import {baseURL} from '../globals';
+
+test('can send bulk email with template name', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const templateName = 'bulk-email-template';
+
+	await ses.send(new CreateEmailTemplateCommand({
+		TemplateName: templateName,
+		TemplateContent: {
+			Subject: 'Hello {{name}}!',
+			Html: '<h1>Hello {{name}}!</h1><p>Your age is {{age}}</p>',
+			Text: 'Hello {{name}}! Your age is {{age}}',
+		},
+	}));
+
+	const response = await ses.send(new SendBulkEmailCommand({
+		FromEmailAddress: 'sender@example.com',
+		DefaultContent: {
+			Template: {
+				TemplateName: templateName,
+				TemplateData: JSON.stringify({name: 'Default', age: '25'}),
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['user1@example.com'],
+				},
+				ReplacementEmailContent: {
+					ReplacementTemplate: {
+						ReplacementTemplateData: JSON.stringify({name: 'John', age: '30'}),
+					},
+				},
+			},
+			{
+				Destination: {
+					ToAddresses: ['user2@example.com'],
+				},
+				ReplacementEmailContent: {
+					ReplacementTemplate: {
+						ReplacementTemplateData: JSON.stringify({name: 'Jane', age: '28'}),
+					},
+				},
+			},
+		],
+	}));
+
+	expect(response.BulkEmailEntryResults).toHaveLength(2);
+	expect(response.BulkEmailEntryResults?.[0]?.Status).toBe('SUCCESS');
+	expect(response.BulkEmailEntryResults?.[1]?.Status).toBe('SUCCESS');
+
+	const s: Store = (await axios({
+		method: 'get',
+		baseURL,
+		url: '/store',
+	})).data;
+
+	expect(s.emails).toHaveLength(2);
+	expect(s.emails[0]).toMatchObject({
+		subject: 'Hello John!',
+		body: {
+			html: '<h1>Hello John!</h1><p>Your age is 30</p>',
+			text: 'Hello John! Your age is 30',
+		},
+		destination: {
+			to: ['user1@example.com'],
+		},
+	});
+	expect(s.emails[1]).toMatchObject({
+		subject: 'Hello Jane!',
+		body: {
+			html: '<h1>Hello Jane!</h1><p>Your age is 28</p>',
+			text: 'Hello Jane! Your age is 28',
+		},
+		destination: {
+			to: ['user2@example.com'],
+		},
+	});
+});
+
+test('can send bulk email with inline template content', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const response = await ses.send(new SendBulkEmailCommand({
+		FromEmailAddress: 'sender@example.com',
+		DefaultContent: {
+			Template: {
+				TemplateContent: {
+					Subject: 'Welcome {{name}}',
+					Html: '<p>Welcome {{name}}!</p>',
+					Text: 'Welcome {{name}}!',
+				},
+				TemplateData: JSON.stringify({name: 'Default User'}),
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['user1@example.com'],
+				},
+				ReplacementEmailContent: {
+					ReplacementTemplate: {
+						ReplacementTemplateData: JSON.stringify({name: 'Alice'}),
+					},
+				},
+			},
+		],
+	}));
+
+	expect(response.BulkEmailEntryResults).toHaveLength(1);
+	expect(response.BulkEmailEntryResults?.[0]?.Status).toBe('SUCCESS');
+
+	const s: Store = (await axios({
+		method: 'get',
+		baseURL,
+		url: '/store',
+	})).data;
+
+	const lastEmail = s.emails[s.emails.length - 1];
+	expect(lastEmail).toMatchObject({
+		subject: 'Welcome Alice',
+		body: {
+			html: '<p>Welcome Alice!</p>',
+			text: 'Welcome Alice!',
+		},
+		destination: {
+			to: ['user1@example.com'],
+		},
+	});
+});
+
+test('returns error when template not found', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new SendBulkEmailCommand({
+		FromEmailAddress: 'sender@example.com',
+		DefaultContent: {
+			Template: {
+				TemplateName: 'non-existent-template',
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['user1@example.com'],
+				},
+			},
+		],
+	}))).rejects.toThrow();
+});
+
+test('returns error when missing from email address', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new SendBulkEmailCommand({
+		DefaultContent: {
+			Template: {
+				TemplateContent: {
+					Subject: 'Test',
+					Text: 'Test content',
+				},
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['user1@example.com'],
+				},
+			},
+		],
+	}))).rejects.toThrow();
+});
+
+test('handles invalid email addresses in bulk entries', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const response = await ses.send(new SendBulkEmailCommand({
+		FromEmailAddress: 'sender@example.com',
+		DefaultContent: {
+			Template: {
+				TemplateContent: {
+					Subject: 'Test Subject',
+					Text: 'Test content',
+				},
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['valid@example.com'],
+				},
+			},
+			{
+				Destination: {
+					ToAddresses: ['invalid-email'],
+				},
+			},
+		],
+	}));
+
+	expect(response.BulkEmailEntryResults).toHaveLength(2);
+	expect(response.BulkEmailEntryResults?.[0]?.Status).toBe('SUCCESS');
+	expect(response.BulkEmailEntryResults?.[1]?.Status).toBe('FAILED');
+	expect(response.BulkEmailEntryResults?.[1]?.Error).toBe('Invalid recipient email address(es)');
+});
+
+test('handles invalid template data JSON', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	await expect(ses.send(new SendBulkEmailCommand({
+		FromEmailAddress: 'sender@example.com',
+		DefaultContent: {
+			Template: {
+				TemplateContent: {
+					Subject: 'Test {{name}}',
+					Text: 'Hello {{name}}',
+				},
+				TemplateData: 'invalid json',
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['user1@example.com'],
+				},
+			},
+		],
+	}))).rejects.toThrow();
+});
+
+test('supports multiple destination types (to, cc, bcc)', async () => {
+	const ses = new SESv2Client({
+		endpoint: baseURL,
+		region: 'aws-ses-v2-local',
+		credentials: {accessKeyId: 'ANY_STRING', secretAccessKey: 'ANY_STRING'},
+	});
+
+	const response = await ses.send(new SendBulkEmailCommand({
+		FromEmailAddress: 'sender@example.com',
+		ReplyToAddresses: ['reply@example.com'],
+		DefaultContent: {
+			Template: {
+				TemplateContent: {
+					Subject: 'Test Subject',
+					Text: 'Test content',
+				},
+			},
+		},
+		BulkEmailEntries: [
+			{
+				Destination: {
+					ToAddresses: ['to@example.com'],
+					CcAddresses: ['cc@example.com'],
+					BccAddresses: ['bcc@example.com'],
+				},
+			},
+		],
+	}));
+
+	expect(response.BulkEmailEntryResults).toHaveLength(1);
+	expect(response.BulkEmailEntryResults?.[0]?.Status).toBe('SUCCESS');
+
+	const s: Store = (await axios({
+		method: 'get',
+		baseURL,
+		url: '/store',
+	})).data;
+
+	const lastEmail = s.emails[s.emails.length - 1];
+	expect(lastEmail).toMatchObject({
+		destination: {
+			to: ['to@example.com'],
+			cc: ['cc@example.com'],
+			bcc: ['bcc@example.com'],
+		},
+		replyTo: ['reply@example.com'],
+	});
+});


### PR DESCRIPTION
Fix: #48 

---

I added tests for the following SES v2 APIs:

- [x] createEmailTemplate.ts
- [x] deleteEmailTemplate.ts
- [x] getAccount.ts
- [x] getEmailTemplate.ts
- [x] sendBulkEmail.ts