### PR TITLE
fix: serve dashboard when installed under a dot-prefixed directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,11 @@ const server = async (partialConfig: Partial<Config> = {}): Promise<Server> => {
 	app.use(express.urlencoded({extended: false, limit: '25mb'}));
 
 	app.get('/', (req, res) => {
-		res.sendFile(path.join(__dirname, '../static/index.html'));
+		// Pass the file relative to a root, rather than as one absolute path. Express 5's send
+		// defaults `dotfiles` to 'ignore', which 404s if _any_ path segment starts with a dot -
+		// and npx/pnpm dlx install us under dot-prefixed cache dirs (.npm/_npx, .pnpm).
+		// With `root` set, the dotfiles check only applies to the path within the root.
+		res.sendFile('index.html', {root: path.join(__dirname, '../static')});
 	});
 
 	app.post('/clear-store', (req, res) => {

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -1,0 +1,64 @@
+import {test, expect} from 'vitest';
+import axios from 'axios';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type {Server} from 'http';
+import {getAddress} from '../src/address';
+import {baseURL} from './globals';
+
+test('serves the web dashboard at /', async () => {
+	const res = await axios({
+		method: 'get',
+		baseURL,
+		url: '/',
+	});
+
+	expect(res.status).toBe(200);
+	expect(res.headers['content-type']).toContain('text/html');
+	expect(res.data).toContain('aws-ses-v2-local');
+});
+
+// Regression test for https://github.com/domdomegg/aws-ses-v2-local/issues/106
+// npx and pnpm dlx install the package under dot-prefixed cache directories
+// (~/.npm/_npx/..., .../node_modules/.pnpm/...). Express 5's send defaults
+// `dotfiles` to 'ignore', which 404s the dashboard if we resolve the file as a
+// single absolute path containing such a segment.
+test('serves the web dashboard when installed under a dot-prefixed directory', async () => {
+	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aws-ses-v2-local-'));
+	// A dot-prefixed ancestor directory, as npx/pnpm dlx would create
+	const installDir = path.join(tmp, '.npx-cache', 'aws-ses-v2-local');
+	await fs.mkdir(installDir, {recursive: true});
+	await fs.cp(path.join(__dirname, '..', 'src'), path.join(installDir, 'src'), {recursive: true});
+	await fs.cp(path.join(__dirname, '..', 'static'), path.join(installDir, 'static'), {recursive: true});
+
+	let s: Server | undefined;
+	try {
+		const {default: serverFromDotDir} = await import(path.join(installDir, 'src', 'index.ts'));
+		s = await serverFromDotDir({port: 0, host: '127.0.0.1'}) as Server;
+
+		const res = await axios({
+			method: 'get',
+			baseURL: getAddress(s),
+			url: '/',
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.data).toContain('aws-ses-v2-local');
+	} finally {
+		if (s) {
+			await new Promise<void>((resolve, reject) => {
+				s!.close((err) => {
+					if (err) {
+						reject(err);
+						return;
+					}
+
+					resolve();
+				});
+			});
+		}
+
+		await fs.rm(tmp, {recursive: true, force: true});
+	}
+});


### PR DESCRIPTION
Fixes #106.

`GET /` returned a `NotFoundError` stack trace instead of the dashboard whenever the package was run via `npx` or `pnpm dlx`. Sending emails was unaffected.

## Cause

Express 5 bundles `send@1.x`, which [defaults `dotfiles` to `'ignore'`](https://github.com/pillarjs/send/blob/1.2.1/index.js#L114-L116). When a file is resolved as a single absolute path, that check applies to *every* path segment, so a dot-prefixed ancestor directory makes the file look missing.

`npx` and `pnpm dlx` always install under exactly such directories:

- `~/.npm/_npx/<hash>/node_modules/aws-ses-v2-local/static/index.html`
- `.../node_modules/.pnpm/aws-ses-v2-local@2.10.1/.../static/index.html`

This regressed in 2.9.0 with the Express 4 → 5 bump. Express 4 bundled `send@0.19.x`, which defaulted `dotfiles` to `undefined` and did not treat ancestors as hidden.

## Fix

Pass the file relative to a `root`, which scopes the dotfiles check to the path within that root rather than the whole absolute path.

## Note on the test

A plain `GET /` test passes even against the broken code, since the repo itself isn't under a dot-prefixed path — which is how this shipped. The added regression test copies the source into a `.npx-cache/` directory and starts a server from there, reproducing the real condition. Reverting the fix makes it fail with the reported 404.

Also verified end-to-end: packed the tarball, installed into `.../.npm/_npx/<hash>/node_modules/`, ran the CLI, and confirmed `GET /` returns 200 with the dashboard HTML and no error in the logs.
